### PR TITLE
Third component of the gx summation should involve pixel (i-1,j+1)

### DIFF
--- a/src/SITI/main.cpp
+++ b/src/SITI/main.cpp
@@ -314,7 +314,7 @@ int main(int argc, char **argv) {
 			for(int j = 1 ; j < width-1 ; ++j) {
 				double gx = -  static_cast<double>(frame1.data[POS(i-1,j-1)])
 						   -2*static_cast<double>(frame1.data[POS(i-1,j)])
-						   -  static_cast<double>(frame1.data[POS(i,j+1)])
+						   -  static_cast<double>(frame1.data[POS(i-1,j+1)])
 						   +  static_cast<double>(frame1.data[POS(i+1,j-1)])
 						   +2*static_cast<double>(frame1.data[POS(i+1,j)])
 						   +  static_cast<double>(frame1.data[POS(i+1,j+1)]);


### PR DESCRIPTION
First of all I would like to thank you for open-sourcing this implementation!

A while back, I made an implementation of the ITU-T P.910 SI / TI metrics myself, and I was surprised to find out that my SI / TI results differ from those generated by your code. After source code inspection, I think there might be an error in your gx calculation. In particular, I believe the third component of the gx summation should involve pixel (i-1,j+1) instead of pixel (i,j+1).