### PR TITLE
Outer set of pixels (i.e., rows 0 and height-1, columns 0 and width-1…

### DIFF
--- a/src/SITI/main.cpp
+++ b/src/SITI/main.cpp
@@ -335,9 +335,14 @@ int main(int argc, char **argv) {
 				double g = std::sqrt(gx*gx+gy*gy);
 
 				add(si, g);
+			}
+		}
 
-				if (bFrame2)
+		if (bFrame2) {
+			for(int i = 0 ; i < height; ++i) {
+				for(int j = 0; j < width; ++j) {
 					add(ti, static_cast<double>(frame1.data[POS(i,j)])-static_cast<double>(frame2.data[POS(i,j)]));
+				}
 			}
 		}
 


### PR DESCRIPTION
…) were excluded from TI calculation.