### PR TITLE
Python correction

### DIFF
--- a/python/siti.py
+++ b/python/siti.py
@@ -76,6 +76,8 @@ def analyze_video(video):
             height = frame.shape[-3]
             frame = frame.reshape((height, width))
 
+        frame = frame.astype('float32')
+
         print("frame {} of video {}".format(i, video))
         for feature in features:
             v = features[feature].calc(frame)

--- a/python/siti.py
+++ b/python/siti.py
@@ -70,7 +70,7 @@ def analyze_video(video):
         "ti": TiFeatures()
     }
     i = 0
-    for frame in skvideo.io.vreader(video):
+    for frame in skvideo.io.vreader(video, as_grey=True):
         print("frame {} of video {}".format(i, video))
         for feature in features:
             v = features[feature].calc(frame)

--- a/python/siti.py
+++ b/python/siti.py
@@ -17,17 +17,13 @@
 
 import argparse
 import sys
-import os
-import json
 from abc import ABC, abstractmethod
 from multiprocessing import Pool
 import multiprocessing
 from scipy import ndimage
-
 import numpy as np
 import pandas as pd
 import skvideo.io
-import scipy
 
 
 class Feature(ABC):

--- a/python/siti.py
+++ b/python/siti.py
@@ -38,7 +38,8 @@ class Feature(ABC):
     def calc(self, frame):
         pass
 
-    def get_values(self):
+    @property
+    def values(self):
         return self._values
 
 
@@ -87,7 +88,7 @@ def analyze_video(video):
 
     result = {}
     for feature in features:
-        result[feature] = features[feature].get_values()
+        result[feature] = features[feature].values
     df = pd.DataFrame(result)
     df["frame"] = range(len(df))
     df["video"] = video

--- a/python/siti.py
+++ b/python/siti.py
@@ -45,7 +45,9 @@ class SiFeatures(Feature):
         self._values = []
 
     def calc(self, frame):
-        value = ndimage.sobel(frame).std()
+        sobx = ndimage.sobel(frame, axis=0)
+        soby = ndimage.sobel(frame, axis=1)
+        value = np.hypot(sobx, soby).std()
         self._values.append(value)
         return value
 

--- a/python/siti.py
+++ b/python/siti.py
@@ -71,6 +71,11 @@ def analyze_video(video):
     }
     i = 0
     for frame in skvideo.io.vreader(video, as_grey=True):
+        if len(frame.shape) > 2:
+            width = frame.shape[-2]
+            height = frame.shape[-3]
+            frame = frame.reshape((height, width))
+
         print("frame {} of video {}".format(i, video))
         for feature in features:
             v = features[feature].calc(frame)

--- a/python/siti.py
+++ b/python/siti.py
@@ -19,6 +19,7 @@ import argparse
 import sys
 import os
 import json
+from abc import ABC, abstractmethod
 from multiprocessing import Pool
 import multiprocessing
 from scipy import ndimage
@@ -29,12 +30,13 @@ import skvideo.io
 import scipy
 
 
-class Feature:
+class Feature(ABC):
     def __init__(self):
         self._values = []
 
+    @abstractmethod
     def calc(self, frame):
-        raise NotImplementedError("not implemented")
+        pass
 
     def get_values(self):
         return self._values

--- a/python/siti.py
+++ b/python/siti.py
@@ -41,9 +41,6 @@ class Feature:
 
 
 class SiFeatures(Feature):
-    def __init__(self):
-        self._values = []
-
     def calc(self, frame):
         sobx = ndimage.sobel(frame, axis=0)
         soby = ndimage.sobel(frame, axis=1)

--- a/python/siti.py
+++ b/python/siti.py
@@ -51,7 +51,7 @@ class SiFeatures(Feature):
 
 class TiFeatures(Feature):
     def __init__(self):
-        self._values = []
+        super().__init__()
         self._previous_frame = None
 
     def calc(self, frame):

--- a/python/siti.py
+++ b/python/siti.py
@@ -21,6 +21,7 @@ import os
 import json
 from multiprocessing import Pool
 import multiprocessing
+from scipy import ndimage
 
 import numpy as np
 import pandas as pd
@@ -44,7 +45,6 @@ class SiFeatures(Feature):
         self._values = []
 
     def calc(self, frame):
-        from scipy import ndimage
         value = ndimage.sobel(frame).std()
         self._values.append(value)
         return value


### PR DESCRIPTION
The python script has basicaly three errors:
- Processing must be done only in the luminance channel;
- The arrays used are of type UINT8 that do not represent the results of the operations correctly;
- The default options of the Sobel filter of the SciPy package do not detect the edges correctly.

Additionally I made some improvements:
- Cleaning the headers
- The right use of abstract class
- A pythonic way to do a getter.